### PR TITLE
Rebuild neighborlist only when required

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -15,7 +15,7 @@
 using namespace std;
 
 unsigned long calculateFlops(System *system, unsigned int numTimesteps) {
-    unsigned long flops = system->atoms().numberOfComputedForces*45 + system->neighborList().numNeighborPairs()*22; // Forces and neighbor list builds
+    unsigned long flops = system->atoms().numberOfComputedForces*45 + system->neighborList().totalComparedNeighborPairs()*22; // Forces and neighbor list builds
     flops += system->atoms().numberOfAtoms*numTimesteps*(9 + 6 + 9); // Velocity verlet
     flops += system->atoms().numberOfAtoms*numTimesteps*(18); // Periodic boundary conditions
     return flops;
@@ -114,7 +114,7 @@ int main(int args, char *argv[])
 
     // Performance numbers
     int pairsPerSecond = system.atoms().numberOfComputedForces / CPElapsedTimer::totalTime();
-    int neighborPairsPerSecond = system.neighborList().numNeighborPairs() / CPElapsedTimer::totalTime();
+    int neighborPairsPerSecond = system.neighborList().totalComparedNeighborPairs() / CPElapsedTimer::totalTime();
     unsigned long flops = calculateFlops(&system, numTimeSteps);
     float flopsPerSecond = flops / CPElapsedTimer::totalTime();
     unsigned long bytesPerSecond = (pairsPerSecond*12 + neighborPairsPerSecond*6)*sizeof(MDDataType_t);
@@ -122,6 +122,7 @@ int main(int args, char *argv[])
     cout << neighborPairsPerSecond/1e6 << " mega neighbor pairs computed per second (" << neighborPairsPerSecond/1e6 << " mega pairs total)" << endl;
     cout << "Memory read speed: " << bytesPerSecond/1e9 << " gigabytes / sec." << endl;
     cout << "Flops: " << flopsPerSecond/1e9 << " Gflops / sec." << endl;
+    cout << "Built neighborlist every " << (numTimeSteps/system.neighborList().numUpdated()) << " timestep" << endl;
 
     return 0;
 }

--- a/neighborlist.h
+++ b/neighborlist.h
@@ -14,17 +14,27 @@ private:
     CellList  m_cellList;
     System   *m_system;
     MDDataType_t     m_rShellSquared;
-    unsigned int m_numNeighborPairs;
+    unsigned int m_numUpdated;
+    unsigned int m_totalComparedNeighborPairs;
+
+    unsigned int m_numInitialNeighborPairs;
+    unsigned int m_numCurrentNeighborPairs;
 
     void clear();
 public:
     NeighborList();
     void setup(System *system, float rShell);
     void update();
+    unsigned int numUpdated() { return m_numUpdated; }
     inline unsigned int *neighborsForAtomWithIndex(int index) { return m_neighbors[index]; }
     CellList &cellList() { return m_cellList; }
-    unsigned int numNeighborPairs() { return m_numNeighborPairs; }
+    unsigned int totalComparedNeighborPairs() { return m_totalComparedNeighborPairs; }
+
     MDDataType_t averageNumNeighbors();
+    MDDataType_t rShellSquared() { return m_rShellSquared; }
+
+    float currentNeighborPairRatio() { return (float)m_numCurrentNeighborPairs / (float)m_numInitialNeighborPairs; }
+    unsigned int &numCurrentNeighborPairs() { return m_numCurrentNeighborPairs; }
 };
 
 #endif // NEIGHBORLIST_H

--- a/potentials/lennardjones.h
+++ b/potentials/lennardjones.h
@@ -10,7 +10,6 @@ private:
     MDDataType_t m_24epsilon;
     MDDataType_t m_rCutSquared;
     MDDataType_t m_potentialEnergyAtRcut;
-    int   m_timeSinceLastNeighborListUpdate;
     void calculateForcesAllPairs(System *system);
 public:
     LennardJones(MDDataType_t sigma, MDDataType_t epsilon, MDDataType_t cutoffRadius);

--- a/system.cpp
+++ b/system.cpp
@@ -30,7 +30,7 @@ System::~System()
 
 void System::initialize(MDDataType_t cutoffRadius) {
     m_rCut = cutoffRadius;
-    m_rShell = UnitConverter::lengthFromAngstroms(2.8*3.405);
+    m_rShell = m_rCut * 1.12;
     m_neighborList.setup(this, m_rShell);
     m_initialized = true;
     printStatus();


### PR DESCRIPTION
Keep track of how many atom-pairs are still within rShellSquared and
rebuild neighborlists when this number is too high.

I've also renamed numNeighborPairs to totalComparedNeighborPairs in
neighborlist.h to more accurately describe what it's counting.
