### PR TITLE
Initialize RNG with non-default seed

### DIFF
--- a/math/random.h
+++ b/math/random.h
@@ -9,7 +9,7 @@
 static std::mt19937 generator;
 #else
 // this generator is now thread safe so we can use it with OpenMP.
-static thread_local std::mt19937 generator;
+static thread_local std::mt19937 generator(time(NULL));
 #endif
 
 class Random


### PR DESCRIPTION
Patches the problem that all .cpp files gets a separate generator, which made it hard to seed the generators. Creates problems if you want to run on multiple threads though.